### PR TITLE
Event builder accepting numbers

### DIFF
--- a/source/actionscript/agnostic/src/eu/alebianco/air/extensions/analytics/api/IEventBuilder.as
+++ b/source/actionscript/agnostic/src/eu/alebianco/air/extensions/analytics/api/IEventBuilder.as
@@ -12,6 +12,6 @@ package eu.alebianco.air.extensions.analytics.api {
 
 public interface IEventBuilder extends IHitBuilder {
 	function withLabel(label:String):IEventBuilder;
-	function withValue(value:int):IEventBuilder;
+	function withValue(value:Number):IEventBuilder;
 }
 }


### PR DESCRIPTION
Would be helpful to be able to track floating values instead of integers.
